### PR TITLE
Add `borsh` to data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +285,51 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "borsh"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "brotli-sys"
@@ -787,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -1113,6 +1164,15 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -1335,6 +1395,7 @@ name = "ibc"
 version = "0.6.0"
 dependencies = [
  "anomaly",
+ "borsh",
  "bytes",
  "chrono",
  "dyn-clonable",
@@ -1516,7 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2064,6 +2125,15 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -23,6 +23,7 @@ mocks = [ "tendermint-testgen", "sha2" ]
 ibc-proto = { version = "0.8.0", path = "../proto" }
 ics23 = { git = "https://github.com/heliaxdev/ics23", branch = "tomas/update-prost" }
 anomaly = "0.2.0"
+borsh = { version = "0.9.0", optional = true }
 chrono = "0.4.19"
 thiserror = "1.0.26"
 serde_derive = "1.0.104"
@@ -62,4 +63,4 @@ sha2 = { version = "0.9.3" }
 [[test]]
 name = "mbt"
 path = "tests/mbt.rs"
-required-features = ["mocks"]
+required-features = ["mocks", "borsh"]

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -5,6 +5,10 @@ use serde_derive::{Deserialize, Serialize};
 use super::error;
 
 /// Type of the client, depending on the specific consensus algorithm.
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ClientType {
     Tendermint = 1,

--- a/modules/src/ics02_client/height.rs
+++ b/modules/src/ics02_client/height.rs
@@ -9,6 +9,10 @@ use ibc_proto::ibc::core::client::v1::Height as RawHeight;
 
 use crate::ics02_client::error::{Error, Kind};
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Height {
     /// Previously known as "epoch"

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -239,6 +239,10 @@ impl ConnectionEnd {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Counterparty {
     client_id: ClientId,

--- a/modules/src/ics03_connection/version.rs
+++ b/modules/src/ics03_connection/version.rs
@@ -8,6 +8,10 @@ use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
 use crate::ics03_connection::error::Kind;
 
 /// Stores the identifier and the features supported by a version
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Version {
     /// unique version identifier

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -277,6 +277,10 @@ impl ChannelEnd {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Counterparty {
     pub port_id: PortId,
@@ -345,6 +349,10 @@ impl From<Counterparty> for RawCounterparty {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Order {
     None = 0,

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -1,11 +1,15 @@
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
+#[cfg(feature = "borsh")]
+use std::io::{ErrorKind, Write};
 use std::str::FromStr;
 
 use anomaly::fail;
 use serde::{Deserialize, Serialize};
 use tendermint_proto::Protobuf;
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
 use ibc_proto::ibc::core::channel::v1::{
     Channel as RawChannel, Counterparty as RawCounterparty,
     IdentifiedChannel as RawIdentifiedChannel,
@@ -98,6 +102,28 @@ impl Default for ChannelEnd {
             connection_hops: vec![],
             version: "".to_string(),
         }
+    }
+}
+
+#[cfg(feature = "borsh")]
+impl BorshSerialize for ChannelEnd {
+    fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let vec = self
+            .encode_vec()
+            .expect("ChannelEnd encoding shouldn't fail");
+        writer.write_all(&vec)
+    }
+}
+
+#[cfg(feature = "borsh")]
+impl BorshDeserialize for ChannelEnd {
+    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
+        ChannelEnd::decode_vec(buf).map_err(|e| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("Error decoding ChannelEnd: {}", e),
+            )
+        })
     }
 }
 

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -176,7 +176,7 @@ pub mod test_util {
             281_815_u64.try_into().unwrap(),
         );
 
-        let vs = ValidatorSet::new(vec![v1], Some(v1));
+        let vs = ValidatorSet::new(vec![v1.clone()], Some(v1));
 
         Header {
             signed_header: shdr,

--- a/modules/src/ics23_commitment/commitment.rs
+++ b/modules/src/ics23_commitment/commitment.rs
@@ -43,6 +43,10 @@ impl From<Vec<u8>> for CommitmentRoot {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CommitmentPath;
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct CommitmentProofBytes {
@@ -94,6 +98,10 @@ impl TryFrom<CommitmentProofBytes> for RawMerkleProof {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, PartialEq, Eq, Hash, Deserialize, Default)]
 pub struct CommitmentPrefix {
     bytes: Vec<u8>,

--- a/modules/src/ics24_host/identifier.rs
+++ b/modules/src/ics24_host/identifier.rs
@@ -137,6 +137,10 @@ impl TryFrom<String> for ChainId {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ClientId(String);
 
@@ -216,6 +220,10 @@ impl PartialEq<str> for ClientId {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ConnectionId(String);
 
@@ -286,6 +294,10 @@ impl PartialEq<str> for ConnectionId {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PortId(String);
 
@@ -322,6 +334,10 @@ impl Default for PortId {
     }
 }
 
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ChannelId(String);
 


### PR DESCRIPTION
I'd like to add `borsh` to the data types that Anoma is using, to encode/decode them easily.
For this time, we don't have to merge this PR. When the mainstream supports `prost` 0.8.0, we can rebase for other fixes.