### PR TITLE
(example) Explicitly patch tendermint-rs for namada v0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ exclude = [
     "proto-compiler"
 ]
 
-# [patch.crates-io]
-# tendermint              = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-rpc          = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-proto        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-testgen      = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
+[patch.crates-io]
+tendermint              = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"}
+tendermint-rpc          = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"}
+tendermint-proto        = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"}
+tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"}
+tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"}
+tendermint-testgen      = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"}

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -30,8 +30,3 @@ substrate-std = [
   "sp-runtime/std",
   "sp-std/std",
 ]
-
-[patch.crates-io]
-tendermint                        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-tendermint-proto                  = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-tendermint-light-client-verifier  = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -45,23 +45,19 @@ num-traits = { version = "0.2.14", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 
 [dependencies.tendermint]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 default-features = false
 
 [dependencies.tendermint-testgen]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 optional = true
 default-features = false
 
@@ -71,8 +67,8 @@ tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter", "json
 test-log = { version = "0.2.8", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.23.5", features = ["http-client", "websocket-client"] }
+tendermint-testgen = "0.23.5"
 
 [[test]]
 name = "mbt"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -29,8 +29,7 @@ tonic = { version = "0.6", optional = true, default-features = false }
 serde = { version = "1.0", default-features = false }
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 default-features = false
 
 [features]

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -58,27 +58,22 @@ flex-error = { version = "0.4.4", default-features = false, features = ["std", "
 signal-hook = "0.3.13"
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 
 [dependencies.tendermint]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 features = ["secp256k1"]
 
 [dependencies.tendermint-rpc]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 features = ["http-client", "websocket-client"]
 
 [dependencies.tendermint-light-client]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 features = ["unstable"]
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 
 [dependencies.abscissa_core]
 version = "=0.6.0"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -71,29 +71,24 @@ version = "0.4.0"
 features = ["num-bigint", "serde"]
 
 [dependencies.tendermint]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 features = ["secp256k1"]
 
 [dependencies.tendermint-rpc]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 features = ["http-client", "websocket-client"]
 
 [dependencies.tendermint-light-client]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 default-features = false
 features = ["rpc-client", "secp256k1", "unstable"]
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "95c52476bc37927218374f94ac8e2a19bd35bec9"
+version = "0.23.5"
 
 [dev-dependencies]
 ibc = { version = "0.12.0", path = "../modules", features = ["mocks"] }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -18,8 +18,8 @@ ibc             = { path = "../../modules" }
 ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
-tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9" }
-tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client", "websocket-client"] }
+tendermint      = "0.23.5"
+tendermint-rpc  = { version = "0.23.5", features = ["http-client", "websocket-client"] }
 
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.31"


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/527

Note the `Cargo.lock` remains unchanged from before, but now we only specify our patching in one place