### PR TITLE
Explicitly patch tendermint-rs for `eth-bridge-integration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,9 +495,9 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "contracts"
-version = "0.4.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9424f2ca1e42776615720e5746eed6efa19866fdbaac2923ab51c294ac4d1f2"
+checksum = "f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3211,8 +3211,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3241,8 +3241,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "flex-error",
  "serde",
@@ -3254,8 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -3275,21 +3275,20 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
  "tendermint",
- "tendermint-rpc",
  "time",
 ]
 
 [[package]]
 name = "tendermint-proto"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3305,8 +3304,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3338,8 +3337,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-testgen"
-version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abciplus#2e9e0d058a68e2534974ff7d22b9058d4ebda3be"
+version = "0.23.6"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b#bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ exclude = [
     "proto-compiler"
 ]
 
-# [patch.crates-io]
-# tendermint              = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-rpc          = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-proto        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-light-client-verifier = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-testgen      = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
+[patch.crates-io]
+# patched to a commit on the `eth-bridge-integration` branch of our fork
+tendermint              = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"}
+tendermint-rpc          = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"}
+tendermint-proto        = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"}
+tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"}
+tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"}
+tendermint-testgen      = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b"}

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -30,8 +30,3 @@ substrate-std = [
   "sp-runtime/std",
   "sp-std/std",
 ]
-
-# [patch.crates-io]
-# tendermint                        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-proto                  = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-# tendermint-light-client-verifier  = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -45,23 +45,19 @@ num-traits = { version = "0.2.14", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 
 [dependencies.tendermint]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 default-features = false
 
 [dependencies.tendermint-testgen]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 optional = true
 default-features = false
 
@@ -71,8 +67,8 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "=0.23.6", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "=0.23.6" } # Needed for generating (synthetic) light blocks.
 
 [[test]]
 name = "mbt"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -32,8 +32,7 @@ schemars    = { version = "0.8", optional = true }
 base64      = { version = "0.13", default-features = false, features = ["alloc"] }
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version          = "=0.23.6"
 default-features = false
 
 [features]

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -60,27 +60,22 @@ dialoguer = "0.10.0"
 console = "0.15.0"
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 
 [dependencies.tendermint]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 features = ["secp256k1"]
 
 [dependencies.tendermint-rpc]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 features = ["http-client", "websocket-client"]
 
 [dependencies.tendermint-light-client]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 features = ["unstable"]
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 
 [dependencies.abscissa_core]
 version = "=0.6.0"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -73,29 +73,24 @@ version = "0.4.0"
 features = ["num-bigint", "serde"]
 
 [dependencies.tendermint]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 features = ["secp256k1"]
 
 [dependencies.tendermint-rpc]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 features = ["http-client", "websocket-client"]
 
 [dependencies.tendermint-light-client]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 default-features = false
 features = ["rpc-client", "secp256k1", "unstable"]
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/heliaxdev/tendermint-rs"
-branch = "bat/abciplus"
+version = "=0.23.6"
 
 [dev-dependencies]
 ibc = { version = "0.14.0", path = "../modules", features = ["mocks"] }
@@ -105,4 +100,4 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 
 # Needed for generating (synthetic) light blocks.
-tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus" }
+tendermint-testgen = { version = "=0.23.6" }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -19,8 +19,8 @@ ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
 ibc-test-framework = { path = "../test-framework" }
-tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus" }
-tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus", features = ["http-client", "websocket-client"] }
+tendermint      = { version = "=0.23.6" }
+tendermint-rpc  = { version = "=0.23.6", features = ["http-client", "websocket-client"] }
 
 serde_json = "1"
 time = "0.3"

--- a/tools/test-framework/Cargo.toml
+++ b/tools/test-framework/Cargo.toml
@@ -18,8 +18,8 @@ ibc             = { path = "../../modules" }
 ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
-tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus" }
-tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abciplus", features = ["http-client", "websocket-client"] }
+tendermint      = { version = "=0.23.6" }
+tendermint-rpc  = { version = "=0.23.6", features = ["http-client", "websocket-client"] }
 
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.34"


### PR DESCRIPTION
For https://github.com/anoma/namada/pull/531

- In individual crate `Cargo.toml`s, reset the tendermint version specified to what it was in [ibc v0.14.0](https://github.com/informalsystems/hermes/releases/tag/v0.14.0), which is what this fork branch is based off
- patch at the top level to use our `tendermint-rs` fork, rather than using it directly in individual crates