### PR TITLE
Merge Tendermint v0.37.0-rc1 into the eth-bridge-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "flex-error",
  "serde",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=8c8935e9b3d901b5f9229e34e5b7f90248397b5d#8c8935e9b3d901b5f9229e34e5b7f90248397b5d"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=7c6a483218c8e897189c6af17939e154878597a5#7c6a483218c8e897189c6af17939e154878597a5"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "libc",
  "num_threads",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ exclude = [
 
 [patch.crates-io]
 # patched to a commit on the `eth-bridge-integration` branch of our fork
-tendermint              = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "8c8935e9b3d901b5f9229e34e5b7f90248397b5d"}
-tendermint-rpc          = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "8c8935e9b3d901b5f9229e34e5b7f90248397b5d"}
-tendermint-proto        = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "8c8935e9b3d901b5f9229e34e5b7f90248397b5d"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "8c8935e9b3d901b5f9229e34e5b7f90248397b5d"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "8c8935e9b3d901b5f9229e34e5b7f90248397b5d"}
-tendermint-testgen      = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "8c8935e9b3d901b5f9229e34e5b7f90248397b5d"}
+tendermint              = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "7c6a483218c8e897189c6af17939e154878597a5"}
+tendermint-rpc          = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "7c6a483218c8e897189c6af17939e154878597a5"}
+tendermint-proto        = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "7c6a483218c8e897189c6af17939e154878597a5"}
+tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "7c6a483218c8e897189c6af17939e154878597a5"}
+tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "7c6a483218c8e897189c6af17939e154878597a5"}
+tendermint-testgen      = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "7c6a483218c8e897189c6af17939e154878597a5"}

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -29,7 +29,7 @@ mocks = ["tendermint-testgen", "clock", "std"]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.17.1", path = "../proto", default-features = false }
 ics23 = { version = "0.7.0", default-features = false }
-time = { version = "0.3", default-features = false }
+time = { version = "=0.3.11", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1", default-features = false }


### PR DESCRIPTION
We update the `tendermint-rs` to point to version `v0.37.0-rc1` instead of `0.37.x`.

It seems the following gaia tests now fail. However these are all `Gaia` tests which do not matter in Namada's case.

failures:
  tests::clear_packet::test_clear_packet
  tests::client_expiration::test_channel_expiration
  tests::client_expiration::test_create_on_expired_client
  tests::client_expiration::test_packet_expiration
  tests::client_settings::test_client_options
  tests::connection_delay::test_connection_delay
  tests::memo::test_memo
  tests::query_packet::test_query_packet_pending
  tests::supervisor::test_supervisor
  tests::ternary_transfer::test_ternary_ibc_transfer
  tests::transfer::test_ibc_transfer
  tests::transfer::test_nary_ibc_transfer
  tests::transfer::test_self_connected_ibc_transfer
  tests::transfer::test_self_connected_nary_ibc_transfer


