### PR TITLE
Update to latest tendermint-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "flex-error",
  "serde",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=9694eaa42799eec2af2af06a15c7cd779f48fb9c#9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "libc",
  "num_threads",

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -7,9 +7,9 @@ resolver = "2"
 [dependencies]
 ibc = { path = "../../modules", default-features = false }
 ibc-proto = { path = "../../proto", default-features = false }
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", default-features = false }
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", default-features = false }
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", default-features = false }
+tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c", default-features = false }
+tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c", default-features = false }
+tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c", default-features = false }
 
 sp-core = { version = "5.0.0", default-features = false, optional = true }
 sp-io = { version = "5.0.0", default-features = false, optional = true }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -29,7 +29,7 @@ mocks = ["tendermint-testgen", "clock", "std"]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.17.1", path = "../proto", default-features = false }
 ics23 = { version = "0.7.0", default-features = false }
-time = { version = "0.3", default-features = false }
+time = { version = "=0.3.11", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1", default-features = false }
@@ -46,22 +46,22 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 
 [dependencies.tendermint]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 default-features = false
 
 [dependencies.tendermint-proto]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 default-features = false
 
 [dependencies.tendermint-testgen]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 optional = true
 default-features = false
 
@@ -71,8 +71,8 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c" } # Needed for generating (synthetic) light blocks.
 
 [[test]]
 name = "mbt"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -33,7 +33,7 @@ base64      = { version = "0.13", default-features = false, features = ["alloc"]
 
 [dependencies.tendermint-proto]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 default-features = false
 
 [features]

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -61,26 +61,26 @@ console = "0.15.0"
 
 [dependencies.tendermint-proto]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 
 [dependencies.tendermint]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 features = ["secp256k1"]
 
 [dependencies.tendermint-rpc]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 features = ["http-client", "websocket-client"]
 
 [dependencies.tendermint-light-client]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 features = ["unstable"]
 
 [dependencies.tendermint-light-client-verifier]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 
 [dependencies.abscissa_core]
 version = "=0.6.0"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -74,28 +74,28 @@ features = ["num-bigint", "serde"]
 
 [dependencies.tendermint]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 features = ["secp256k1"]
 
 [dependencies.tendermint-rpc]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 features = ["http-client", "websocket-client"]
 
 [dependencies.tendermint-light-client]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 default-features = false
 features = ["rpc-client", "secp256k1", "unstable"]
 
 [dependencies.tendermint-light-client-verifier]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 default-features = false
 
 [dependencies.tendermint-proto]
 git = "https://github.com/heliaxdev/tendermint-rs"
-rev = "e6c684731f21bffd89886d3e91074b96aee074ba"
+rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c"
 
 [dev-dependencies]
 ibc = { version = "0.14.0", path = "../modules", features = ["mocks"] }
@@ -105,4 +105,4 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 
 # Needed for generating (synthetic) light blocks.
-tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
+tendermint-testgen = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c" }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -19,8 +19,8 @@ ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
 ibc-test-framework = { path = "../test-framework" }
-tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
-tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", features = ["http-client", "websocket-client"] }
+tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c" }
+tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c", features = ["http-client", "websocket-client"] }
 
 serde_json = "1"
 time = "0.3"

--- a/tools/test-framework/Cargo.toml
+++ b/tools/test-framework/Cargo.toml
@@ -18,8 +18,8 @@ ibc             = { path = "../../modules" }
 ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
-tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
-tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", features = ["http-client", "websocket-client"] }
+tendermint      = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c" }
+tendermint-rpc  = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c", features = ["http-client", "websocket-client"] }
 
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.34"


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/825

Adapted from https://github.com/heliaxdev/ibc-rs/pull/9 (includes pinning of a `time` version to `=3.11`)